### PR TITLE
Fix first movement delta being way too large

### DIFF
--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -28,7 +28,7 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
 
     // initialize timers
     last_update = rclcpp::Time{0, 0, RCL_ROS_TIME};
-    last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
+    last_vel = rclcpp::Time{0, 0, RCL_ROS_TIME};
 
     // initialize first odom message
     update_odom_from_vel(geometry_msgs::msg::Twist(), rclcpp::Duration::from_seconds(0.1));
@@ -77,8 +77,6 @@ void MobileRobotSimulator::get_params()
 void MobileRobotSimulator::start()
 {
     wall_time_origin_ = std::chrono::steady_clock::now();
-    last_update = now();
-    last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
     loop_timer = node_->create_wall_timer(std::chrono::duration<double>(1.0/publish_rate),[this](){update_loop();});
     is_running = true;
     RCLCPP_INFO(logger_, "Started mobile robot simulator update loop, listening on cmd_vel topic");

--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -26,6 +26,11 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
             [this](geometry_msgs::msg::Twist::ConstSharedPtr msg){vel_callback(*msg);});
     }
 
+    // initialize timers
+    wall_time_origin_ = std::chrono::steady_clock::now();
+    last_update = now();
+    last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
+
     // initialize first odom message
     update_odom_from_vel(geometry_msgs::msg::Twist(), rclcpp::Duration::from_seconds(0.1));
     odom.header.stamp = last_update;

--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -27,7 +27,7 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
     }
 
     // initialize timers (sim time is initialized in start())
-    last_update = rclcpp::Time{0, RCL_ROS_TIME};
+    last_update = rclcpp::Time{0, 0, RCL_ROS_TIME};
     last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
 
     // initialize first odom message

--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -26,9 +26,6 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
             [this](geometry_msgs::msg::Twist::ConstSharedPtr msg){vel_callback(*msg);});
     }
 
-    // initialize timers
-    last_update = now();
-    last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
     // initialize first odom message
     update_odom_from_vel(geometry_msgs::msg::Twist(), rclcpp::Duration::from_seconds(0.1));
     odom.header.stamp = last_update;
@@ -76,6 +73,8 @@ void MobileRobotSimulator::get_params()
 void MobileRobotSimulator::start()
 {
     wall_time_origin_ = std::chrono::steady_clock::now();
+    last_update = now();
+    last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
     loop_timer = node_->create_wall_timer(std::chrono::duration<double>(1.0/publish_rate),[this](){update_loop();});
     is_running = true;
     RCLCPP_INFO(logger_, "Started mobile robot simulator update loop, listening on cmd_vel topic");

--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -26,7 +26,7 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
             [this](geometry_msgs::msg::Twist::ConstSharedPtr msg){vel_callback(*msg);});
     }
 
-    // initialize timers (sim time is initialized in start())
+    // initialize timers
     last_update = rclcpp::Time{0, 0, RCL_ROS_TIME};
     last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
 

--- a/src/mobile_robot_simulator.cpp
+++ b/src/mobile_robot_simulator.cpp
@@ -26,9 +26,8 @@ MobileRobotSimulator::MobileRobotSimulator(const rclcpp::Node::SharedPtr& node) 
             [this](geometry_msgs::msg::Twist::ConstSharedPtr msg){vel_callback(*msg);});
     }
 
-    // initialize timers
-    wall_time_origin_ = std::chrono::steady_clock::now();
-    last_update = now();
+    // initialize timers (sim time is initialized in start())
+    last_update = rclcpp::Time{0, RCL_ROS_TIME};
     last_vel = last_update - rclcpp::Duration::from_seconds(0.1);
 
     // initialize first odom message


### PR DESCRIPTION
I've had a bug where the first movement delta was in the order of 1e6. This was caused by a wrong initialization of `last_update`.

`now()` internally uses `wall_time_origin_` to determine how long the program has been running. This means using `now()` in the constructor doesn't work yet, because `wall_time_origin_` is only initialized in start().

To fix this I've moved the initialization of `last_update` and `last_vel` to `start()`.